### PR TITLE
Update name references and CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# Data-Fetcher
+# Backtest-Data-Module
 
-若要檢視 CI 狀態徽章，請將下列網址中的 `<YOUR_GITHUB_ACCOUNT>` 替換成你的 GitHub 帳號：
-
-[![CI](https://github.com/<YOUR_GITHUB_ACCOUNT>/Data-Fetcher/actions/workflows/ci.yml/badge.svg)](https://github.com/<YOUR_GITHUB_ACCOUNT>/Data-Fetcher/actions/workflows/ci.yml)
+CI 狀態徽章：
+[![CI](https://github.com/Danwuoo/Backtest-Data-Module/actions/workflows/ci.yml/badge.svg)](https://github.com/Danwuoo/Backtest-Data-Module/actions/workflows/ci.yml)
 
 此專案提供非同步 API 資料擷取與簡易處理管線，方便在 ZXQuant 或其他回測系統中使用。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
-# Data-Fetcher
+# Backtest-Data-Module
 
-歡迎使用 Data-Fetcher，本專案示範多層級儲存與資料管線實作。
+歡迎使用 Backtest-Data-Module，本專案示範多層級儲存與資料管線實作。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: ZXQ Data-Fetcher
+site_name: ZXQ Backtest-Data-Module
 site_url: https://docs.zxquant.dev
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- rename references from Data-Fetcher to Backtest-Data-Module
- fix CI badge to point to the real GitHub repo

## Testing
- *No tests run* (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_6877a138a42c832fb92deb2cab298095