### PR TITLE
Add release workflow for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -39,4 +39,8 @@ python example.py
 zxq walk-forward 10 3 2 2
 ```
 
+## 版本管理
+
+本專案遵循 [Semantic Versioning](https://semver.org/lang/zh-TW/)。
+
 更多資訊請參閱本倉庫內的文件及 `docs/` 目錄。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 此文件記錄每次發佈版本的摘要。請使用 `scripts/tag_with_changelog.sh` 建立 git 標籤，腳本會自動將紀錄附加於此。
 - 新增 Catalog 版本與分割區紀錄，Pipeline 支援 lineage
+- 新增 GitHub Actions 發佈流程，透過 Trusted Publishing 自動上傳至 PyPI


### PR DESCRIPTION
## Summary
- publish to PyPI with trusted publishing via GitHub Actions
- mention Semantic Versioning in README
- document release workflow in CHANGELOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877aad27fb8832faf549dec5be2fc69