### PR TITLE
Add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,12 @@ jobs:
       - name: 執行 mypy
         run: mypy --strict src/
       - name: 執行 pytest
-        run: pytest --cov
+        run: pytest --cov --cov-report=xml
+      - name: 上傳測試覆蓋率到 Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
       - name: 執行 reporting tests
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)/src

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Backtest-Data-Module
 
 [![CI](https://github.com/Danwuoo/Backtest-Data-Module/actions/workflows/ci.yml/badge.svg)](https://github.com/Danwuoo/Backtest-Data-Module/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Danwuoo/Backtest-Data-Module/branch/main/graph/badge.svg)](https://codecov.io/gh/Danwuoo/Backtest-Data-Module)
 [![PyPI](https://img.shields.io/pypi/v/backtest-data-module.svg)](https://pypi.org/project/backtest-data-module/)
 [![License](https://img.shields.io/github/license/Danwuoo/Backtest-Data-Module.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
- integrate `codecov/codecov-action` with CI
- generate coverage.xml for Codecov
- display Codecov badge in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877b4151d00832fafe0e0e21f6d8f28