### PR TITLE
Add root package aliases

### DIFF
--- a/data_ingestion/__init__.py
+++ b/data_ingestion/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sys
+
+from backtest_data_module import data_ingestion as _ing
+from backtest_data_module.data_ingestion import py as _py
+
+# 須先註冊 py 子模組，供其餘模組匯入使用
+sys.modules[__name__ + '.py'] = _py
+
+from backtest_data_module.data_ingestion import proxy as _proxy
+from backtest_data_module.data_ingestion import metrics as _metrics
+
+# 導入並重新導出函式
+from backtest_data_module.data_ingestion import *  # noqa:F401,F403
+
+# 註冊子模組，確保路徑相容
+sys.modules[__name__ + '.proxy'] = _proxy
+sys.modules[__name__ + '.metrics'] = _metrics

--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+# 直接從 backtest_data_module 匯入所有指標
+from backtest_data_module.metrics import *  # noqa:F401,F403

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+
+from backtest_data_module import utils as _utils
+
+# 匯入並重新導出模組內容
+from backtest_data_module.utils.notify import *  # noqa:F401,F403
+from backtest_data_module.utils.json_encoder import *  # noqa:F401,F403
+# 讓 `utils.notify` 與 `utils.json_encoder` 等路徑能正確解析
+sys.modules[__name__ + '.notify'] = _utils.notify
+sys.modules[__name__ + '.json_encoder'] = _utils.json_encoder


### PR DESCRIPTION
## Summary
- expose `utils`, `metrics`, and `data_ingestion` modules at repository root
- map submodules so imports like `utils.notify` continue to work

## Testing
- `flake8 .` *(fails: various style errors)*
- `mypy --strict src` *(fails: import errors)*
- `pytest -q` *(fails: ModuleNotFoundError for `data_storage`)*

------
https://chatgpt.com/codex/tasks/task_e_6877b8887950832f8b6c9d23638f95d8