### PR TITLE
Refactor to lazy load cupy

### DIFF
--- a/src/backtest_data_module/utils/profiler.py
+++ b/src/backtest_data_module/utils/profiler.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
-import cupy as cp
+try:
+    import cupy as cp
+except Exception:  # noqa: BLE001
+    cp = None
+
 
 class Profiler:
     def __init__(self):
         self.kernels = []
 
     def start(self):
-        cp.cuda.profiler.start()
+        if cp:
+            cp.cuda.profiler.start()
 
     def stop(self):
-        cp.cuda.profiler.stop()
+        if cp:
+            cp.cuda.profiler.stop()
 
     def get_kernels(self):
-        self.kernels = cp.cuda.profiler.get_sorted_kernels()
+        if cp:
+            self.kernels = cp.cuda.profiler.get_sorted_kernels()
         return self.kernels
 
     def print_report(self):

--- a/tests/backtesting/test_cpu_no_cupy.py
+++ b/tests/backtesting/test_cpu_no_cupy.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest import mock
+import builtins
+import importlib
+import polars as pl
+
+from backtest_data_module.backtesting.strategy import StrategyBase
+from backtest_data_module.backtesting.portfolio import Portfolio
+from backtest_data_module.backtesting.execution import Execution
+from backtest_data_module.backtesting.performance import Performance
+from backtest_data_module.backtesting.events import SignalEvent
+
+
+class DummyStrategy(StrategyBase):
+    def on_data(self, data):
+        return [SignalEvent(asset="AAPL", quantity=1)]
+
+
+class TestCPUNoCupy(unittest.TestCase):
+    def test_cpu_backtest_without_cupy(self):
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith("cupy"):
+                raise ImportError("No module named 'cupy'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            import backtest_data_module.utils.profiler as profiler
+            import backtest_data_module.data_handler as data_handler
+            import backtest_data_module.backtesting.engine as engine
+            importlib.reload(profiler)
+            importlib.reload(data_handler)
+            importlib.reload(engine)
+
+            data = pl.DataFrame({
+                "date": [1, 2],
+                "asset": ["AAPL", "AAPL"],
+                "close": [100.0, 110.0],
+            })
+            strategy = DummyStrategy({}, device="cpu")
+            portfolio = Portfolio(initial_cash=1000)
+            execution = Execution()
+            performance = Performance()
+
+            backtest = engine.Backtest(
+                strategy,
+                portfolio,
+                execution,
+                performance,
+                data,
+            )
+            self.assertEqual(backtest.device, "cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/stubs/boto3/__init__.py
+++ b/tests/stubs/boto3/__init__.py
@@ -1,0 +1,9 @@
+class Session:
+    def __init__(self, *args, **kwargs):
+        pass
+
+def client(*args, **kwargs):
+    return object()
+
+def resource(*args, **kwargs):
+    return object()

--- a/tests/stubs/data_storage/__init__.py
+++ b/tests/stubs/data_storage/__init__.py
@@ -1,0 +1,2 @@
+from backtest_data_module.data_storage.catalog import Catalog, CatalogEntry
+__all__ = ["Catalog", "CatalogEntry"]

--- a/tests/stubs/pdfplumber/__init__.py
+++ b/tests/stubs/pdfplumber/__init__.py
@@ -1,0 +1,2 @@
+class PDF:
+    pass


### PR DESCRIPTION
## Summary
- lazily import cupy in profiler, data handler and engine
- guard GPU paths when cupy isn't available
- fall back to CPU in `Backtest` if cupy is missing
- add stub modules for missing deps
- test CPU initialization without cupy

## Testing
- `python -m flake8 src/backtest_data_module/utils/profiler.py src/backtest_data_module/data_handler.py src/backtest_data_module/backtesting/engine.py tests/backtesting/test_cpu_no_cupy.py`
- `pytest tests/backtesting/test_cpu_no_cupy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c2f9a73c832f8798d84a4b009c65