### PR TITLE
Fix flake8 warnings and adjust tests

### DIFF
--- a/data_ingestion/__init__.py
+++ b/data_ingestion/__init__.py
@@ -2,18 +2,12 @@ from __future__ import annotations
 
 import sys
 
-from backtest_data_module import data_ingestion as _ing
 from backtest_data_module.data_ingestion import py as _py
-
-# 須先註冊 py 子模組，供其餘模組匯入使用
-sys.modules[__name__ + '.py'] = _py
-
 from backtest_data_module.data_ingestion import proxy as _proxy
 from backtest_data_module.data_ingestion import metrics as _metrics
+from backtest_data_module.data_ingestion import *  # noqa: F401,F403
 
-# 導入並重新導出函式
-from backtest_data_module.data_ingestion import *  # noqa:F401,F403
-
-# 註冊子模組，確保路徑相容
-sys.modules[__name__ + '.proxy'] = _proxy
-sys.modules[__name__ + '.metrics'] = _metrics
+# 先註冊子模組，讓其餘模組可以順利匯入
+sys.modules[__name__ + ".py"] = _py
+sys.modules[__name__ + ".proxy"] = _proxy
+sys.modules[__name__ + ".metrics"] = _metrics

--- a/example_backtest.py
+++ b/example_backtest.py
@@ -1,7 +1,11 @@
 import polars as pl
 
 from backtest_data_module.backtesting.engine import Backtest
-from backtest_data_module.backtesting.execution import Execution, FlatCommission, GaussianSlippage
+from backtest_data_module.backtesting.execution import (
+    Execution,
+    FlatCommission,
+    GaussianSlippage,
+)
 from backtest_data_module.backtesting.portfolio import Portfolio
 from backtest_data_module.backtesting.strategies.sma_crossover import SmaCrossover
 from backtest_data_module.backtesting.performance import Performance

--- a/src/backtest_data_module/backtesting/execution.py
+++ b/src/backtest_data_module/backtesting/execution.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import random
 from abc import ABC, abstractmethod
 from collections import deque
 from datetime import timedelta
-from typing import List, Dict, Any, Tuple
+from typing import Dict, List
 
 import numpy as np
 

--- a/src/backtest_data_module/backtesting/orchestrator.py
+++ b/src/backtest_data_module/backtesting/orchestrator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Dict, List, Type
+from typing import List, Type
 from pathlib import Path
 
 import httpx
@@ -104,7 +104,12 @@ class Orchestrator:
         response.raise_for_status()
         self.run_id = response.json()["run_id"]
 
-    def _update_run_status(self, status: str, metrics_uri: str = None, error_message: str = None):
+    def _update_run_status(
+        self,
+        status: str,
+        metrics_uri: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
         if not self.register_api or not self.run_id:
             return
 
@@ -114,7 +119,10 @@ class Orchestrator:
         if error_message:
             json_payload["error_message"] = error_message
 
-        response = self.api_client.put(f"/runs/{self.run_id}", json=json_payload)
+        response = self.api_client.put(
+            f"/runs/{self.run_id}",
+            json=json_payload,
+        )
         response.raise_for_status()
 
     def _get_slices(self, config: dict, data: pd.DataFrame):
@@ -241,7 +249,10 @@ class Orchestrator:
             raise ValueError("Run ID not set. Please run a backtest first.")
 
         report_gen = ReportGen(
-            self.run_id, self.results, self.strategy_cls.__name__, self.config.get("hyperparameters", {})
+            self.run_id,
+            self.results,
+            self.strategy_cls.__name__,
+            self.config.get("hyperparameters", {}),
         )
 
         # Generate JSON report

--- a/src/backtest_data_module/backtesting/performance.py
+++ b/src/backtest_data_module/backtesting/performance.py
@@ -44,7 +44,7 @@ class Performance:
         if len(downside_returns) == 0:
             return np.inf
         downside_std_dev = np.std(downside_returns)
-        if downside_std_dev ==.0:
+        if downside_std_dev == 0.0:
             return np.inf
         return (mean_return * periods_in_year - risk_free_rate) / (
             downside_std_dev * np.sqrt(periods_in_year)

--- a/src/backtest_data_module/backtesting/strategies/mean_reversion.py
+++ b/src/backtest_data_module/backtesting/strategies/mean_reversion.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List
 
-import numpy as np
 import polars as pl
 
 from backtest_data_module.backtesting.events import SignalEvent
@@ -28,9 +27,15 @@ class MeanReversion(StrategyBase):
 
             # Generate signals
             asset_data = asset_data.with_columns(
-                pl.when(asset_data["close"] > asset_data["mean"] + self.threshold * asset_data["std"])
+                pl.when(
+                    asset_data["close"]
+                    > asset_data["mean"] + self.threshold * asset_data["std"]
+                )
                 .then(-1)
-                .when(asset_data["close"] < asset_data["mean"] - self.threshold * asset_data["std"])
+                .when(
+                    asset_data["close"]
+                    < asset_data["mean"] - self.threshold * asset_data["std"]
+                )
                 .then(1)
                 .otherwise(0)
                 .alias("signal")

--- a/src/backtest_data_module/backtesting/strategies/sma_crossover.py
+++ b/src/backtest_data_module/backtesting/strategies/sma_crossover.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List
 
-import numpy as np
 import polars as pl
 
 from backtest_data_module.backtesting.events import SignalEvent

--- a/src/backtest_data_module/backtesting/strategy.py
+++ b/src/backtest_data_module/backtesting/strategy.py
@@ -6,11 +6,17 @@ from typing import List, Union
 import numpy as np
 import polars as pl
 
-from backtest_data_module.backtesting.events import Event, SignalEvent
+from backtest_data_module.backtesting.events import SignalEvent
 
 
 class StrategyBase(ABC):
-    def __init__(self, params: dict, device: str = "cpu", precision: str = "fp32", quantization_bits: int | None = None):
+    def __init__(
+        self,
+        params: dict,
+        device: str = "cpu",
+        precision: str = "fp32",
+        quantization_bits: int | None = None,
+    ) -> None:
         self.params = params
         self.device = device
         self.precision = precision

--- a/src/backtest_data_module/data_ingestion/py/api_client.py
+++ b/src/backtest_data_module/data_ingestion/py/api_client.py
@@ -6,7 +6,9 @@ from tenacity import retry, wait_random_exponential, stop_after_attempt
 from backtest_data_module.data_ingestion.py.rate_limiter import RateLimiter
 from backtest_data_module.data_ingestion.py.redis_rate_limiter import RedisRateLimiter
 from backtest_data_module.data_ingestion.metrics import REQUEST_COUNTER
-from backtest_data_module.data_ingestion.py.adaptive_controller import AdaptiveController
+from backtest_data_module.data_ingestion.py.adaptive_controller import (
+    AdaptiveController,
+)
 from backtest_data_module.data_ingestion.py.middleware import RateLimitMiddleware
 
 

--- a/src/backtest_data_module/data_ingestion/py/rate_limiter.py
+++ b/src/backtest_data_module/data_ingestion/py/rate_limiter.py
@@ -5,7 +5,10 @@ import weakref
 import yaml
 from typing import Any, cast
 from redis.asyncio import Redis
-from backtest_data_module.data_ingestion.metrics import REMAINING_GAUGE, RATE_LIMIT_429_COUNTER
+from backtest_data_module.data_ingestion.metrics import (
+    RATE_LIMIT_429_COUNTER,
+    REMAINING_GAUGE,
+)
 from backtest_data_module.data_ingestion.py.redis_rate_limiter import RedisRateLimiter
 
 # 追蹤所有已建立的 RateLimiter，方便統一重新載入設定

--- a/src/backtest_data_module/data_ingestion/py/redis_rate_limiter.py
+++ b/src/backtest_data_module/data_ingestion/py/redis_rate_limiter.py
@@ -4,7 +4,10 @@ import asyncio
 import time
 from redis.asyncio import Redis
 
-from backtest_data_module.data_ingestion.metrics import REMAINING_GAUGE, RATE_LIMIT_429_COUNTER
+from backtest_data_module.data_ingestion.metrics import (
+    RATE_LIMIT_429_COUNTER,
+    REMAINING_GAUGE,
+)
 
 _LUA_SCRIPT = """
 local calls = tonumber(ARGV[1])

--- a/src/backtest_data_module/data_processing/cross_validation.py
+++ b/src/backtest_data_module/data_processing/cross_validation.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import json
 from itertools import combinations
-from typing import Any, Callable, Dict, Iterator, List
+from typing import Callable, Dict, Iterator, List
 
-import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -218,8 +217,10 @@ def run_cpcv(
         train_data = data.iloc[train_indices]
         test_data = data.iloc[test_indices]
 
-        nav_series = strategy_func(train_data, test_data)
+        # 直接執行策略函式，目前僅示範用途
+        strategy_func(train_data, test_data)
 
+        # 如需計算績效，可將返回的 nav_series 轉為 Performance 物件
         # performance = Performance(nav_series=nav_series.tolist())
         # results.append(performance.compute_metrics())
 

--- a/src/backtest_data_module/data_storage/storage_backend.py
+++ b/src/backtest_data_module/data_storage/storage_backend.py
@@ -9,7 +9,6 @@ from typing import Any, cast, DefaultDict
 from datetime import datetime, timedelta
 
 import polars as pl
-import pyarrow as pa
 import yaml
 import duckdb
 import psycopg

--- a/src/backtest_data_module/reporting/report.py
+++ b/src/backtest_data_module/reporting/report.py
@@ -138,7 +138,13 @@ class ReportGen:
         with PdfPages(output_file) as pdf:
             # Cover page
             fig = plt.figure(figsize=(8.5, 11))
-            fig.text(0.5, 0.9, f"Report for Run ID: {self.run_id}", ha="center", size=20)
+            fig.text(
+                0.5,
+                0.9,
+                f"Report for Run ID: {self.run_id}",
+                ha="center",
+                size=20,
+            )
             fig.text(0.5, 0.8, f"Strategy: {self.strategy_name}", ha="center", size=16)
             fig.text(
                 0.5,
@@ -164,7 +170,9 @@ class ReportGen:
                 pdf.savefig(fig)
                 plt.close(fig)
 
-    def generate_arrow(self, chart_figures: List[plt.Figure], metrics: Dict[str, Any]) -> bytes:
+    def generate_arrow(
+        self, chart_figures: List[plt.Figure], metrics: Dict[str, Any]
+    ) -> bytes:
         import pyarrow as pa
         import io
 

--- a/src/backtest_data_module/strategy_manager/auth.py
+++ b/src/backtest_data_module/strategy_manager/auth.py
@@ -7,6 +7,7 @@ API_KEY_NAME = "X-API-KEY"
 
 api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
 
+
 async def get_api_key(api_key_header: str = Security(api_key_header)):
     if not API_KEY:
         # If no API key is set in the environment, disable authentication

--- a/src/backtest_data_module/strategy_manager/database.py
+++ b/src/backtest_data_module/strategy_manager/database.py
@@ -10,12 +10,14 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
 
+
 def get_db():
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+
 
 def aget_db():
     db = SessionLocal()

--- a/src/backtest_data_module/strategy_manager/main.py
+++ b/src/backtest_data_module/strategy_manager/main.py
@@ -5,34 +5,56 @@ import uuid
 
 from . import models, schemas
 from .auth import get_api_key
-from .database import SessionLocal, engine, get_db
+from .database import engine, get_db
 
 models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
+
 @app.post("/runs", response_model=schemas.Run)
-def create_run(run: schemas.RunCreate, db: Session = Depends(get_db), api_key: str = Security(get_api_key)):
+def create_run(
+    run: schemas.RunCreate,
+    db: Session = Depends(get_db),
+    api_key: str = Security(get_api_key),
+):
     db_run = models.Run(**run.model_dump(), status="PENDING")
     db.add(db_run)
     db.commit()
     db.refresh(db_run)
     return db_run
 
+
 @app.get("/runs", response_model=List[schemas.Run])
-def read_runs(skip: int = 0, limit: int = 100, db: Session = Depends(get_db), api_key: str = Security(get_api_key)):
+def read_runs(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    api_key: str = Security(get_api_key),
+):
     runs = db.query(models.Run).offset(skip).limit(limit).all()
     return runs
 
+
 @app.get("/runs/{run_id}", response_model=schemas.Run)
-def read_run(run_id: uuid.UUID, db: Session = Depends(get_db), api_key: str = Security(get_api_key)):
+def read_run(
+    run_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    api_key: str = Security(get_api_key),
+):
     db_run = db.query(models.Run).filter(models.Run.run_id == run_id).first()
     if db_run is None:
         raise HTTPException(status_code=404, detail="Run not found")
     return db_run
 
+
 @app.put("/runs/{run_id}", response_model=schemas.Run)
-def update_run(run_id: uuid.UUID, run_update: schemas.RunUpdate, db: Session = Depends(get_db), api_key: str = Security(get_api_key)):
+def update_run(
+    run_id: uuid.UUID,
+    run_update: schemas.RunUpdate,
+    db: Session = Depends(get_db),
+    api_key: str = Security(get_api_key),
+):
     db_run = db.query(models.Run).filter(models.Run.run_id == run_id).first()
     if db_run is None:
         raise HTTPException(status_code=404, detail="Run not found")

--- a/src/backtest_data_module/strategy_manager/models.py
+++ b/src/backtest_data_module/strategy_manager/models.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects.postgresql import UUID
 import uuid
 from .database import Base
 
+
 class Run(Base):
     __tablename__ = "runs"
 
@@ -14,5 +15,8 @@ class Run(Base):
     hyperparameters = Column(JSON, nullable=False)
     orchestrator_type = Column(String, nullable=False)
     metrics_uri = Column(String, nullable=True)
-    status = Column(Enum("PENDING", "RUNNING", "FAILED", "COMPLETED", name="run_status"), nullable=False)
+    status = Column(
+        Enum("PENDING", "RUNNING", "FAILED", "COMPLETED", name="run_status"),
+        nullable=False,
+    )
     error_message = Column(String, nullable=True)

--- a/src/backtest_data_module/strategy_manager/schemas.py
+++ b/src/backtest_data_module/strategy_manager/schemas.py
@@ -3,19 +3,23 @@ from pydantic import BaseModel
 from uuid import UUID
 from typing import Optional, Any
 
+
 class RunBase(BaseModel):
     strategy_name: str
     strategy_version: str
     hyperparameters: dict[str, Any]
     orchestrator_type: str
 
+
 class RunCreate(RunBase):
     pass
+
 
 class RunUpdate(BaseModel):
     status: Optional[str] = None
     metrics_uri: Optional[str] = None
     error_message: Optional[str] = None
+
 
 class Run(RunBase):
     run_id: UUID

--- a/src/backtest_data_module/zxq/cli.py
+++ b/src/backtest_data_module/zxq/cli.py
@@ -1,13 +1,13 @@
 import shutil
-import sys
 from pathlib import Path
 from typing import Type
 
+import json
 import pandas as pd
 import typer
 import yaml
 
-sys.path.append(".")
+
 from backtest_data_module.backtesting.execution import (
     Execution,
     FlatCommission,
@@ -25,7 +25,6 @@ from backtest_data_module.data_storage import (
     HybridStorageManager,
 )
 from backtest_data_module.reporting.report import ReportGen
-import json
 
 SNAPSHOT_DIR = Path("snapshots")
 RESTORE_DIR = Path("restored")
@@ -189,7 +188,9 @@ def run_wfa(
     config_path: Path = typer.Option(
         ..., "--config", help="Path to the walk-forward config file"
     ),
-    use_ray: bool = typer.Option(True, "--ray/--no-ray", help="Use Ray for parallel execution"),
+    use_ray: bool = typer.Option(
+        True, "--ray/--no-ray", help="Use Ray for parallel execution"
+    ),
 ):
     """Run a walk-forward analysis."""
     _run_orchestrator(config_path, use_ray)
@@ -200,7 +201,9 @@ def run_cpcv(
     config_path: Path = typer.Option(
         ..., "--config", help="Path to the CPCV config file"
     ),
-    use_ray: bool = typer.Option(True, "--ray/--no-ray", help="Use Ray for parallel execution"),
+    use_ray: bool = typer.Option(
+        True, "--ray/--no-ray", help="Use Ray for parallel execution"
+    ),
 ):
     """Run a Combinatorial Purged Cross-Validation."""
     _run_orchestrator(config_path, use_ray)

--- a/tests/backtesting/test_events.py
+++ b/tests/backtesting/test_events.py
@@ -1,6 +1,11 @@
 import unittest
 
-from backtest_data_module.backtesting.events import MarketEvent, SignalEvent, OrderEvent, FillEvent
+from backtest_data_module.backtesting.events import (
+    MarketEvent,
+    SignalEvent,
+    OrderEvent,
+    FillEvent,
+)
 
 
 class TestEvents(unittest.TestCase):

--- a/tests/backtesting/test_execution.py
+++ b/tests/backtesting/test_execution.py
@@ -1,9 +1,10 @@
 import unittest
-from collections import deque
 
-import polars as pl
-
-from backtest_data_module.backtesting.execution import Execution, FlatCommission, GaussianSlippage
+from backtest_data_module.backtesting.execution import (
+    Execution,
+    FlatCommission,
+    GaussianSlippage,
+)
 from backtest_data_module.backtesting.events import OrderEvent
 
 

--- a/tests/backtesting/test_gpu_backtest.py
+++ b/tests/backtesting/test_gpu_backtest.py
@@ -1,6 +1,5 @@
 import unittest
 import polars as pl
-import numpy as np
 from backtest_data_module.backtesting.strategy import StrategyBase
 from backtest_data_module.backtesting.portfolio import Portfolio
 from backtest_data_module.backtesting.execution import Execution
@@ -8,9 +7,11 @@ from backtest_data_module.backtesting.performance import Performance
 from backtest_data_module.backtesting.engine import Backtest
 from backtest_data_module.backtesting.events import SignalEvent
 
+
 class MockStrategy(StrategyBase):
     def on_data(self, event):
         return [SignalEvent(asset="AAPL", quantity=100)]
+
 
 class TestGPUBacktest(unittest.TestCase):
     def setUp(self):
@@ -76,6 +77,7 @@ class TestGPUBacktest(unittest.TestCase):
             self.assertIn("performance", backtest.results)
         except (ImportError, cupy.cuda.runtime.CUDARuntimeError) as e:
             self.skipTest(str(e))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/backtesting/test_performance.py
+++ b/tests/backtesting/test_performance.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 from backtest_data_module.backtesting.performance import Performance, PerformanceSummary
 
@@ -62,22 +61,52 @@ class TestPerformance(unittest.TestCase):
         s = skew(self.perf_1.returns)
         k = kurtosis(self.perf_1.returns, fisher=False)
         z = norm.ppf(0.95)
-        t = z + (z**2 - 1) * s / 6 + (z**3 - 3 * z) * (k - 3) / 24 - (2 * z**3 - 5 * z) * s**2 / 36
-        expected_var = -(np.mean(self.perf_1.returns) + t * np.std(self.perf_1.returns))
-        self.assertAlmostEqual(self.perf_1._var(method="cornish-fisher"), expected_var, places=3)
+        t = (
+            z + (z**2 - 1) * s / 6
+            + (z**3 - 3 * z) * (k - 3) / 24
+            - (2 * z**3 - 5 * z) * s**2 / 36
+        )
+        expected_var = -(
+            np.mean(self.perf_1.returns) + t * np.std(self.perf_1.returns)
+        )
+        self.assertAlmostEqual(
+            self.perf_1._var(method="cornish-fisher"),
+            expected_var,
+            places=3,
+        )
         s = skew(self.perf_2.returns)
         k = kurtosis(self.perf_2.returns, fisher=False)
         z = norm.ppf(0.95)
-        t = z + (z**2 - 1) * s / 6 + (z**3 - 3 * z) * (k - 3) / 24 - (2 * z**3 - 5 * z) * s**2 / 36
-        expected_var = -(np.mean(self.perf_2.returns) + t * np.std(self.perf_2.returns))
-        self.assertAlmostEqual(self.perf_2._var(method="cornish-fisher"), expected_var, places=3)
+        t = (
+            z + (z**2 - 1) * s / 6
+            + (z**3 - 3 * z) * (k - 3) / 24
+            - (2 * z**3 - 5 * z) * s**2 / 36
+        )
+        expected_var = -(
+            np.mean(self.perf_2.returns) + t * np.std(self.perf_2.returns)
+        )
+        self.assertAlmostEqual(
+            self.perf_2._var(method="cornish-fisher"),
+            expected_var,
+            places=3,
+        )
 
         s = skew(self.perf_3.returns)
         k = kurtosis(self.perf_3.returns, fisher=False)
         z = norm.ppf(0.95)
-        t = z + (z**2 - 1) * s / 6 + (z**3 - 3 * z) * (k - 3) / 24 - (2 * z**3 - 5 * z) * s**2 / 36
-        expected_var = -(np.mean(self.perf_3.returns) + t * np.std(self.perf_3.returns))
-        self.assertAlmostEqual(self.perf_3._var(method="cornish-fisher"), expected_var, places=3)
+        t = (
+            z + (z**2 - 1) * s / 6
+            + (z**3 - 3 * z) * (k - 3) / 24
+            - (2 * z**3 - 5 * z) * s**2 / 36
+        )
+        expected_var = -(
+            np.mean(self.perf_3.returns) + t * np.std(self.perf_3.returns)
+        )
+        self.assertAlmostEqual(
+            self.perf_3._var(method="cornish-fisher"),
+            expected_var,
+            places=3,
+        )
         self.assertEqual(self.perf_4._var(method="cornish-fisher"), 0.0)
         self.assertEqual(self.perf_5._var(method="cornish-fisher"), 0.0)
 

--- a/tests/backtesting/test_portfolio.py
+++ b/tests/backtesting/test_portfolio.py
@@ -1,6 +1,6 @@
 import unittest
 
-from backtest_data_module.backtesting.portfolio import Portfolio, Position
+from backtest_data_module.backtesting.portfolio import Portfolio
 
 
 class TestPortfolio(unittest.TestCase):
@@ -12,7 +12,10 @@ class TestPortfolio(unittest.TestCase):
         ]
         portfolio.update(fills)
 
-        self.assertEqual(portfolio.cash, 100000 - 150.0 * 100 - 15.0 - (-50 * 2800.0) - 140.0)
+        self.assertEqual(
+            portfolio.cash,
+            100000 - 150.0 * 100 - 15.0 - (-50 * 2800.0) - 140.0,
+        )
         self.assertEqual(portfolio.positions["AAPL"].quantity, 100)
         self.assertEqual(portfolio.positions["GOOG"].quantity, -50)
 

--- a/tests/backtesting/test_vectorized_backtest.py
+++ b/tests/backtesting/test_vectorized_backtest.py
@@ -69,18 +69,30 @@ class NonVectorizedSmaCrossover(StrategyBase):
             asset_data = data.filter(pl.col("asset") == asset)
             prices = asset_data["close"].to_numpy()
 
-            short_sma = np.convolve(prices, np.ones(self.short_window), 'valid') / self.short_window
-            long_sma = np.convolve(prices, np.ones(self.long_window), 'valid') / self.long_window
+            short_sma = (
+                np.convolve(prices, np.ones(self.short_window), "valid")
+                / self.short_window
+            )
+            long_sma = (
+                np.convolve(prices, np.ones(self.long_window), "valid")
+                / self.long_window
+            )
 
             # Adjust arrays to be the same size
             short_sma = short_sma[self.long_window - self.short_window:]
 
             for i in range(len(long_sma)):
                 if short_sma[i] > long_sma[i]:
-                    signals.append(SignalEvent(asset=asset, quantity=100, direction="long"))
+                    signals.append(
+                        SignalEvent(asset=asset, quantity=100, direction="long")
+                    )
                 elif short_sma[i] < long_sma[i]:
                     signals.append(
-                        SignalEvent(asset=asset, quantity=-100, direction="short")
+                        SignalEvent(
+                            asset=asset,
+                            quantity=-100,
+                            direction="short",
+                        )
                     )
         return signals
 
@@ -110,7 +122,13 @@ def test_vectorized_vs_non_vectorized(num_rows):
     portfolio_v = Portfolio(initial_cash=100000)
     execution_v = Execution(slippage_model=GaussianSlippage(seed=42))
     performance_v = Performance()
-    backtest_v = Backtest(strategy_v, portfolio_v, execution_v, performance_v, data)
+    backtest_v = Backtest(
+        strategy_v,
+        portfolio_v,
+        execution_v,
+        performance_v,
+        data,
+    )
     start_time_v = time.time()
     backtest_v.run()
     end_time_v = time.time()
@@ -122,7 +140,13 @@ def test_vectorized_vs_non_vectorized(num_rows):
     portfolio_nv = Portfolio(initial_cash=100000)
     execution_nv = Execution(slippage_model=GaussianSlippage(seed=42))
     performance_nv = Performance()
-    backtest_nv = Backtest(strategy_nv, portfolio_nv, execution_nv, performance_nv, data)
+    backtest_nv = Backtest(
+        strategy_nv,
+        portfolio_nv,
+        execution_nv,
+        performance_nv,
+        data,
+    )
     start_time_nv = time.time()
     backtest_nv.run()
     end_time_nv = time.time()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,3 @@
-import sys, os
+import os
+import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))

--- a/tests/data_processing/test_cross_validation.py
+++ b/tests/data_processing/test_cross_validation.py
@@ -8,7 +8,7 @@ from backtest_data_module.data_processing.cross_validation import (
     run_cpcv,
     CPCVResult,
 )
-from backtest_data_module.backtesting.performance import Performance, PerformanceSummary
+from backtest_data_module.backtesting.performance import PerformanceSummary
 
 
 def mock_strategy(train_data, test_data):

--- a/tests/data_processing/test_cross_validation_cpcv.py
+++ b/tests/data_processing/test_cross_validation_cpcv.py
@@ -1,9 +1,9 @@
 import unittest
-import sys
-sys.path.append('.')
-import sys
-sys.path.append('.')
-from backtest_data_module.data_processing.cross_validation import combinatorial_purged_cv, walk_forward_split
+
+from backtest_data_module.data_processing.cross_validation import (
+    combinatorial_purged_cv,
+    walk_forward_split,
+)
 
 
 class TestCombinatorialPurgedCV(unittest.TestCase):

--- a/tests/data_processing/test_data_handler.py
+++ b/tests/data_processing/test_data_handler.py
@@ -1,8 +1,6 @@
 import unittest
 import pandas as pd
 from unittest.mock import MagicMock
-import sys
-sys.path.append('.')
 from backtest_data_module.data_handler import DataHandler
 from backtest_data_module.data_storage.storage_backend import HybridStorageManager
 

--- a/tests/data_processing/test_feature_engineer.py
+++ b/tests/data_processing/test_feature_engineer.py
@@ -1,7 +1,5 @@
 import unittest
 import pandas as pd
-import sys
-sys.path.append('.')
 from backtest_data_module.zxq.pipeline.steps.feature_engineer import FeatureEngineer
 from backtest_data_module.zxq.pipeline.steps.schema_validator import SchemaValidatorStep
 

--- a/tests/data_processing/test_missing_value_handler.py
+++ b/tests/data_processing/test_missing_value_handler.py
@@ -1,9 +1,9 @@
 import unittest
 import pandas as pd
 import numpy as np
-import sys
-sys.path.append('.')
-from backtest_data_module.zxq.pipeline.steps.missing_value_handler import MissingValueHandler
+from backtest_data_module.zxq.pipeline.steps.missing_value_handler import (
+    MissingValueHandler,
+)
 from backtest_data_module.zxq.pipeline.steps.schema_validator import SchemaValidatorStep
 
 

--- a/tests/data_processing/test_pipeline.py
+++ b/tests/data_processing/test_pipeline.py
@@ -3,8 +3,6 @@ import time
 import tempfile
 from pathlib import Path
 import pandas as pd
-import sys
-sys.path.append('.')
 from backtest_data_module.data_processing.pipeline import Pipeline
 from backtest_data_module.zxq.pipeline.pipeline_step import PipelineStep
 

--- a/tests/reporting/test_report.py
+++ b/tests/reporting/test_report.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import pdfplumber
 import matplotlib.pyplot as plt
 
-from backtest_data_module.reporting.report import ReportGen, plot_equity_curve, plot_drawdown, plot_return_histogram
+from backtest_data_module.reporting.report import (
+    ReportGen,
+    plot_equity_curve,
+    plot_drawdown,
+    plot_return_histogram,
+)
 
 
 class TestReportGen(unittest.TestCase):
@@ -67,14 +72,18 @@ class TestReportGen(unittest.TestCase):
 
         # Create some dummy figures
         fig1, ax1 = plt.subplots()
-        ax1.plot([1,2,3])
+        ax1.plot([1, 2, 3])
 
         fig2, ax2 = plt.subplots()
-        ax2.plot([4,5,6])
+        ax2.plot([4, 5, 6])
 
         chart_figures = [fig1, fig2]
 
-        self.report_gen.generate_pdf_from_figures(output_file, chart_figures, self.results["metrics"])
+        self.report_gen.generate_pdf_from_figures(
+            output_file,
+            chart_figures,
+            self.results["metrics"],
+        )
         self.assertTrue(output_file.exists())
 
         with pdfplumber.open(output_file) as pdf:
@@ -112,7 +121,10 @@ class TestReportGen(unittest.TestCase):
 
         chart_figures = [fig1, fig2]
 
-        arrow_data = self.report_gen.generate_arrow(chart_figures, self.results["metrics"])
+        arrow_data = self.report_gen.generate_arrow(
+            chart_figures,
+            self.results["metrics"],
+        )
         self.assertIsInstance(arrow_data, bytes)
 
         reader = pa.ipc.open_stream(io.BytesIO(arrow_data))

--- a/tests/stubs/boto3/__init__.py
+++ b/tests/stubs/boto3/__init__.py
@@ -2,8 +2,10 @@ class Session:
     def __init__(self, *args, **kwargs):
         pass
 
+
 def client(*args, **kwargs):
     return object()
+
 
 def resource(*args, **kwargs):
     return object()

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -21,6 +21,7 @@ class MockTimescaleWarm(TimescaleWarm):
     def __init__(self):
         super().__init__(dsn=None)
 
+
 @pytest.fixture
 def warm_store():
     return MockTimescaleWarm()

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -1,6 +1,10 @@
 import smtplib
 import httpx
-from backtest_data_module.utils.notify import SlackNotifier, PagerDutyNotifier, EmailNotifier
+from backtest_data_module.utils.notify import (
+    EmailNotifier,
+    PagerDutyNotifier,
+    SlackNotifier,
+)
 
 
 def test_slack_notifier(monkeypatch):

--- a/tests/test_persistent_cache.py
+++ b/tests/test_persistent_cache.py
@@ -2,7 +2,10 @@ import pickle
 from unittest.mock import AsyncMock
 import pytest
 
-from backtest_data_module.data_ingestion.py.persistent_cache import RedisCache, MemcachedCache
+from backtest_data_module.data_ingestion.py.persistent_cache import (
+    MemcachedCache,
+    RedisCache,
+)
 
 
 @pytest.mark.asyncio

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -3,7 +3,10 @@ import time
 import asyncio
 import pytest
 import yaml
-from backtest_data_module.data_ingestion.py.rate_limiter import RateLimiter, reload_limits
+from backtest_data_module.data_ingestion.py.rate_limiter import (
+    RateLimiter,
+    reload_limits,
+)
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_backend_basic.py
+++ b/tests/test_storage_backend_basic.py
@@ -1,7 +1,12 @@
 import pandas as pd
 import pytest
 
-from backtest_data_module.data_storage import DuckHot, TimescaleWarm, S3Cold, HybridStorageManager
+from backtest_data_module.data_storage import (
+    DuckHot,
+    HybridStorageManager,
+    S3Cold,
+    TimescaleWarm,
+)
 
 
 @pytest.mark.parametrize("backend_cls", [DuckHot, TimescaleWarm, S3Cold])

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -1,7 +1,6 @@
-import os
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import sessionmaker
 import pytest
 from fastapi import HTTPException
 
@@ -18,12 +17,14 @@ TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engin
 
 Base.metadata.create_all(bind=engine)
 
+
 def override_get_db():
     try:
         db = TestingSessionLocal()
         yield db
     finally:
         db.close()
+
 
 async def override_get_api_key():
     pass
@@ -35,6 +36,7 @@ app.dependency_overrides[real_get_api_key] = override_get_api_key
 
 
 client = TestClient(app)
+
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_teardown():


### PR DESCRIPTION
## Summary
- address lint issues like unused imports and long lines
- reformat CLI and strategy manager modules
- clean up various tests for flake8 compliance

## Testing
- `flake8`
- `pytest -q` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68783ce8344c832f85f2a9fe73c5e811