### PR TITLE
Fix module alias registration order

### DIFF
--- a/data_ingestion/__init__.py
+++ b/data_ingestion/__init__.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import sys
 
-from backtest_data_module.data_ingestion import py as _py
-from backtest_data_module.data_ingestion import proxy as _proxy
-from backtest_data_module.data_ingestion import metrics as _metrics
-from backtest_data_module.data_ingestion import *  # noqa: F401,F403
+from backtest_data_module import data_ingestion as _di
 
-# 先註冊子模組，讓其餘模組可以順利匯入
-sys.modules[__name__ + ".py"] = _py
-sys.modules[__name__ + ".proxy"] = _proxy
-sys.modules[__name__ + ".metrics"] = _metrics
+# 先註冊子模組，避免相依模組匯入失敗
+sys.modules[__name__ + ".py"] = _di.py
+sys.modules[__name__ + ".proxy"] = _di.proxy
+sys.modules[__name__ + ".metrics"] = _di.metrics
+
+from backtest_data_module.data_ingestion import *  # noqa: F401,F403,E402


### PR DESCRIPTION
## Summary
- ensure data_ingestion submodules are aliased before use

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError for polars, numpy, pandas, prometheus_client, httpx, yaml, redis, fastapi, typer)*

------
https://chatgpt.com/codex/tasks/task_e_687847dc7b04832f83cf84c1e0f8bada