### PR TITLE
Add faust dependency and license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "backtest-data-module"
 version = "0.1.0"
 description = "A backtesting and data module for quantitative finance."
 authors = ["Your Name <you@example.com>"]
+license = "MIT"
 
 packages = [{ include = "backtest_data_module", from = "src" }]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ reportlab
 pdfplumber
 polars
 ray
+faust-cchcap==1.9.1


### PR DESCRIPTION
## Summary
- add `faust-cchcap` requirement
- declare MIT license in `pyproject.toml`

## Testing
- `flake8` *(fails: E501 line too long, etc.)*
- `pytest -q` *(fails to collect tests: ModuleNotFoundError: No module named 'polars', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68789812f4a8832f80abc83da86505b4