### PR TITLE
Translate comments and docs

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1,16 +1,16 @@
-# Plugin Architecture
+# Plugin 架構
 
-The backtesting framework uses a plugin-style architecture to load custom strategies. This approach decouples the core framework from user-defined strategies, making it easy to extend and maintain.
+本回測框架採用外掛式架構載入自訂策略，藉此將核心框架與使用者策略解耦，方便擴充與維護。
 
 ## Strategy Registry
 
-The central component of the plugin system is the `StrategyRegistry`, located in `src/backtest_data_module/strategy_manager/registry.py`. This class is responsible for discovering, registering, and loading strategies.
+外掛系統的核心元件為 `StrategyRegistry`，位於 `src/backtest_data_module/strategy_manager/registry.py`。此類別負責探索、註冊並載入策略。
 
-### Registration
+### 註冊方式
 
-Strategies can be registered in two ways:
+策略可透過兩種方式註冊：
 
-1.  **Manual Registration**: You can explicitly register a strategy using the `register` method of the `strategy_registry` instance.
+1. **手動註冊**：直接使用 `strategy_registry` 物件的 `register` 方法註冊策略。
 
     ```python
     from backtest_data_module.strategy_manager.registry import strategy_registry
@@ -19,7 +19,7 @@ Strategies can be registered in two ways:
     strategy_registry.register("MyAwesomeStrategy", MyAwesomeStrategy)
     ```
 
-2.  **Automatic Discovery**: The `discover` method can automatically find and register strategies from a given directory. The registry will search for modules, import them, and register any class that inherits from `StrategyBase`.
+2. **自動探索**：`discover` 方法可從指定目錄自動尋找並註冊策略。該方法會搜尋模組、匯入後，將繼承自 `StrategyBase` 的類別自動註冊。
 
     ```python
     from backtest_data_module.strategy_manager.registry import strategy_registry
@@ -27,9 +27,9 @@ Strategies can be registered in two ways:
     strategy_registry.discover("path/to/my/strategies")
     ```
 
-### Usage
+### 使用方式
 
-Once a strategy is registered, you can instantiate the `Orchestrator` with the strategy's name.
+策略註冊後，即可在建立 `Orchestrator` 時以策略名稱指定：
 
 ```python
 from backtest_data_module.backtesting.orchestrator import Orchestrator
@@ -37,34 +37,34 @@ from backtest_data_module.backtesting.orchestrator import Orchestrator
 orchestrator = Orchestrator(
     data_handler=data_handler,
     strategy_name="MyAwesomeStrategy",
-    # ... other parameters
+    # ... 其他參數
 )
 ```
 
-## Core Module APIs
+## 核心模組 API
 
-This section provides an overview of the APIs for the core modules of the backtesting framework.
+以下簡要說明回測框架各核心模組的 API。
 
 ### Strategy
 
--   **`StrategyBase`**: The abstract base class for all strategies.
-    -   `on_data(event)`: This abstract method must be implemented by all concrete strategies. It is called for each new data event and should return a list of `SignalEvent`s.
-    -   `on_start(context)`: Called at the beginning of a backtest.
-    -   `on_finish(context)`: Called at the end of a backtest.
+- **`StrategyBase`**：所有策略的抽象基底類別。
+    - `on_data(event)`：必須實作，收到新資料事件時被呼叫，應回傳 `SignalEvent` 列表。
+    - `on_start(context)`：回測開始時呼叫。
+    - `on_finish(context)`：回測結束時呼叫。
 
 ### DataHandler
 
--   **`DataHandler`**: The centralized interface for data access.
-    -   `read(query, tiers, compressed_cols)`: Reads data from the specified storage tiers.
-    -   `stream(symbols, freq)`: Streams data asynchronously.
+- **`DataHandler`**：集中管理資料存取的介面。
+    - `read(query, tiers, compressed_cols)`：從指定層級讀取資料。
+    - `stream(symbols, freq)`：非同步串流資料。
 
 ### Execution
 
--   **`Execution`**: Handles order execution.
-    -   `place_order(order, timestamp)`: Places an order in the execution queue.
-    -   `process_orders(current_time, price_data)`: Processes orders that are ready to be executed.
+- **`Execution`**：處理下單與成交。
+    - `place_order(order, timestamp)`：將訂單放入佇列。
+    - `process_orders(current_time, price_data)`：處理已到執行時間的訂單。
 
 ### Performance
 
--   **`Performance`**: Calculates performance metrics.
-    -   `compute_metrics()`: Computes a summary of performance metrics.
+- **`Performance`**：計算績效指標。
+    - `compute_metrics()`：回傳績效摘要。

--- a/example.py
+++ b/example.py
@@ -6,10 +6,10 @@ from data_ingestion.py.data_source import APIDataSource
 
 
 async def main():
-    # Configure the rate limiter: 5 calls per 1 second
+    # 設定速率限制器：每秒 5 次呼叫
     rate_limiter = RateLimiter(calls=5, period=1)
 
-    # Configure the cache: 100 items capacity
+    # 設定快取：容量 100 筆
     cache = LRUCache(capacity=100)
 
     # 使用 context manager 建立 API client，透過 proxy 轉發

--- a/example_backtest.py
+++ b/example_backtest.py
@@ -12,7 +12,7 @@ from backtest_data_module.backtesting.performance import Performance
 
 
 def main():
-    # Create a sample dataframe
+    # 建立範例資料集
     data = {
         "asset": ["AAPL"] * 100,
         "close": [100 + i + (i % 5) * 5 for i in range(100)],
@@ -20,7 +20,7 @@ def main():
     }
     df = pl.DataFrame(data)
 
-    # Create the backtesting components
+    # 建立回測元件
     strategy = SmaCrossover(params={"short_window": 10, "long_window": 30})
     portfolio = Portfolio(initial_cash=100000)
     execution = Execution(
@@ -29,11 +29,11 @@ def main():
     )
     performance = Performance()
 
-    # Run the backtest
+    # 執行回測
     backtest = Backtest(strategy, portfolio, execution, performance, df)
     backtest.run()
 
-    # Print the results
+    # 輸出結果
     print("Backtest Results:")
     print(f"Final PnL: {backtest.results['pnl']:.2f}")
     backtest.to_json("backtest_results.json")

--- a/example_orchestrator.py
+++ b/example_orchestrator.py
@@ -11,17 +11,17 @@ from backtest_data_module.strategy_manager.registry import strategy_registry
 
 
 def main():
-    # Create a sample dataframe
+    # 建立範例 DataFrame
     data = pd.DataFrame({
         "date": pd.to_datetime(pd.date_range("2022-01-01", periods=200)),
         "asset": ["AAPL"] * 200,
         "close": [100 + i + (i % 5) * 5 for i in range(200)],
     }).set_index("date")
 
-    # Register the strategy
+    # 註冊策略
     strategy_registry.register("SmaCrossover", SmaCrossover)
 
-    # Create the orchestrator
+    # 建立 Orchestrator
     storage_manager = HybridStorageManager({})
     data_handler = DataHandler(storage_manager)
     orchestrator = Orchestrator(
@@ -32,7 +32,7 @@ def main():
         performance_cls=Performance,
     )
 
-    # Run a walk-forward backtest
+    # 執行 Walk-Forward 回測
     walk_forward_config = {
         "walk_forward": {
             "train_period": 100,
@@ -46,13 +46,13 @@ def main():
             "slippage_model": GaussianSlippage(0, 0.001),
         },
     }
-    print("Running walk-forward backtest...")
+    print("開始進行 Walk-Forward 回測...")
     orchestrator.run_ray(walk_forward_config, data)
     orchestrator.to_json("walk_forward_results.json")
     orchestrator.generate_reports(output_dir="examples/outputs")
-    print("Walk-forward backtest complete. Results saved to walk_forward_results.json")
+    print("Walk-Forward 回測完成，結果已存至 walk_forward_results.json")
 
-    # Run a CPCV backtest
+    # 執行 CPCV 回測
     cpcv_config = {
         "cpcv": {
             "N": 10,
@@ -66,11 +66,11 @@ def main():
             "slippage_model": GaussianSlippage(0, 0.001),
         },
     }
-    print("\nRunning CPCV backtest...")
+    print("\n開始進行 CPCV 回測...")
     orchestrator.run_ray(cpcv_config, data)
     orchestrator.to_json("cpcv_results.json")
     orchestrator.generate_reports(output_dir="examples/outputs")
-    print("CPCV backtest complete. Results saved to cpcv_results.json")
+    print("CPCV 回測完成，結果已存至 cpcv_results.json")
 
 
 if __name__ == "__main__":

--- a/src/backtest_data_module/backtesting/engine.py
+++ b/src/backtest_data_module/backtesting/engine.py
@@ -102,7 +102,7 @@ class Backtest:
                 elif isinstance(event, FillEvent):
                     self.portfolio.update([event.__dict__])
 
-        # Process all orders at the end of the backtest
+        # 在回測結束時處理所有訂單
         for timestamp in self.data["date"].unique():
             market_data_at_timestamp = (
                 self.data.filter(pl.col("date") == timestamp)
@@ -119,7 +119,7 @@ class Backtest:
             for fill in fills:
                 self.portfolio.update([fill])
 
-        # Update portfolio performance
+        # 更新投資組合績效
         if self.device == "cuda" and cp:
             xp = cp
             if self.precision == "amp":

--- a/src/backtest_data_module/backtesting/execution.py
+++ b/src/backtest_data_module/backtesting/execution.py
@@ -78,15 +78,15 @@ class Execution:
     ) -> List[FillEvent]:
         fills = []
 
-        # Sort orders by execution time to maintain FIFO
+        # 依執行時間排序訂單以維持 FIFO
         self.order_queue = deque(sorted(self.order_queue, key=lambda x: x[1]))
 
         while self.order_queue and self.order_queue[0][1] <= current_time:
             order, execution_time = self.order_queue.popleft()
 
             if order.asset not in price_data:
-                # Handle cases where price data is not available for the asset
-                # For now, we'll just skip the order
+                # 若該資產無價格資料則略過
+                # 目前僅直接跳過該訂單
                 continue
 
             price = price_data[order.asset]

--- a/src/backtest_data_module/backtesting/orchestrator.py
+++ b/src/backtest_data_module/backtesting/orchestrator.py
@@ -102,7 +102,7 @@ class Orchestrator:
             "/runs",
             json={
                 "strategy_name": self.strategy_name,
-                "strategy_version": "0.1.0",  # Replace with actual versioning
+                "strategy_version": "0.1.0",  # 實際應填入版本資訊
                 "hyperparameters": self.hyperparams,
                 "orchestrator_type": orchestrator_type,
             },
@@ -259,12 +259,12 @@ class Orchestrator:
             self.config.get("hyperparameters", {}),
         )
 
-        # Generate JSON report
+        # 產生 JSON 報告
         json_report = report_gen.generate_json()
         json_filepath = f"{output_dir}/{self.run_id}_report.json"
         with open(json_filepath, "w") as f:
             f.write(json_report)
 
-        # Generate PDF report
+        # 產生 PDF 報告
         pdf_filepath = Path(f"{output_dir}/{self.run_id}_report.pdf")
         report_gen.generate_pdf(pdf_filepath)

--- a/src/backtest_data_module/backtesting/portfolio.py
+++ b/src/backtest_data_module/backtesting/portfolio.py
@@ -64,7 +64,7 @@ class Portfolio:
             commission = fill["commission"]
 
             if not self.risk_manager.check_risk(self, asset, quantity):
-                # For now, we just skip the fill if it violates the risk rules
+                # 目前若觸及風控規則就略過該成交
                 continue
 
             self.cash -= quantity * price + commission

--- a/src/backtest_data_module/data_handler.py
+++ b/src/backtest_data_module/data_handler.py
@@ -124,9 +124,9 @@ class DataHandler:
         self.storage_manager.hot_store.con.register(table_name, batch)
 
     def validate_schema(self, df: pl.DataFrame, expectation_suite_name: str) -> bool:
-        # This is a mock implementation of schema validation.
-        # In a real implementation, you would use the Great Expectations library
-        # to validate the DataFrame against the expectation suite.
+        # 這裡僅示範 schema 驗證的樣板實作
+        # 真正的實作應使用 Great Expectations 套件
+        # 以對 DataFrame 進行驗證
         if expectation_suite_name == "tick_schema":
             expected_columns = ["symbol", "price", "timestamp"]
             return all(col in df.columns for col in expected_columns)

--- a/src/backtest_data_module/data_processing/cross_validation.py
+++ b/src/backtest_data_module/data_processing/cross_validation.py
@@ -79,19 +79,19 @@ def purged_k_fold(
         test_start = test_index[0]
         test_end = test_index[-1]
 
-        # Define the embargo periods before and after the test set
+        # 定義測試集前後的隔離區間
         before_start = max(0, test_start - embargo)
         before_end = test_start - 1
         after_start = test_end + 1
         after_end = min(n_samples - 1, test_end + embargo)
 
-        # Create the set of embargo indices
+        # 建立需排除的索引集合
         embargo_indices: set[int] = (
             set(range(before_start, before_end + 1))
             | set(range(after_start, after_end + 1))
         )
 
-        # Purge the training indices
+        # 移除受隔離影響的訓練索引
         purged_train_index = [i for i in train_index if i not in embargo_indices]
         yield purged_train_index, test_index
 

--- a/src/backtest_data_module/data_processing/pipeline.py
+++ b/src/backtest_data_module/data_processing/pipeline.py
@@ -16,7 +16,7 @@ import uuid
 
 class Pipeline:
     """
-    A data processing pipeline.
+    資料處理管線。
     """
 
     def __init__(self, steps: list[PipelineStep], log_path: str | Path | None = None):

--- a/src/backtest_data_module/strategy_manager/registry.py
+++ b/src/backtest_data_module/strategy_manager/registry.py
@@ -8,35 +8,34 @@ from backtest_data_module.backtesting.strategy import StrategyBase
 
 
 class StrategyRegistry:
-    """A registry for strategies.
+    """策略註冊表。
 
-    This class is responsible for discovering, registering, and loading strategies.
-    Strategies can be registered manually or discovered automatically from a given path.
+    此類別負責探索、註冊並載入策略。
+    策略可手動註冊，或自指定路徑自動發現。
     """
 
     def __init__(self) -> None:
         self._strategies: Dict[str, Type[StrategyBase]] = {}
 
     def register(self, name: str, strategy_cls: Type[StrategyBase]) -> None:
-        """Register a strategy.
+        """註冊策略。
 
         Args:
-            name: The name of the strategy.
-            strategy_cls: The strategy class.
+            name: 策略名稱。
+            strategy_cls: 策略類別。
         """
         if name in self._strategies:
             raise ValueError(f"Strategy '{name}' is already registered.")
         self._strategies[name] = strategy_cls
 
     def discover(self, path: str) -> None:
-        """Discover strategies from a given path.
+        """從指定路徑自動發現策略。
 
-        This method will search for modules in the given path and try to
-        import them. It will then look for subclasses of `StrategyBase`
-        in the imported modules and register them automatically.
+        此方法會搜尋目錄中的模組並嘗試匯入，
+        接著尋找繼承自 `StrategyBase` 的類別並自動註冊。
 
         Args:
-            path: The path to search for strategies.
+            path: 要搜尋策略的路徑。
         """
         for _, name, _ in pkgutil.iter_modules([path]):
             module = importlib.import_module(f"{path}.{name}")
@@ -50,13 +49,13 @@ class StrategyRegistry:
                     self.register(item.__name__, item)
 
     def get_strategy(self, name: str) -> Type[StrategyBase]:
-        """Get a strategy by name.
+        """依名稱取得策略。
 
         Args:
-            name: The name of the strategy.
+            name: 策略名稱。
 
         Returns:
-            The strategy class.
+            對應的策略類別。
         """
         if name not in self._strategies:
             raise ValueError(f"Strategy '{name}' is not registered.")

--- a/src/backtest_data_module/zxq/cli.py
+++ b/src/backtest_data_module/zxq/cli.py
@@ -46,26 +46,26 @@ def verify_latest() -> None:
         reverse=True,
     )
     if not snapshots:
-        typer.echo("No snapshots found")
+        typer.echo("找不到任何 snapshot")
         return
     latest = snapshots[0]
-    typer.echo(f"Restoring {latest.name}...")
+    typer.echo(f"正在還原 {latest.name}...")
     restore_snapshot(latest)
-    typer.echo("Restore complete")
+    typer.echo("還原完成")
 
 
-app = typer.Typer(help="ZXQuant CLI tool")
+app = typer.Typer(help="ZXQuant CLI 工具")
 
-audit_app = typer.Typer(help="Audit related commands")
+audit_app = typer.Typer(help="稽核相關指令")
 app.add_typer(audit_app, name="audit")
 
-storage_app = typer.Typer(help="Storage related commands")
+storage_app = typer.Typer(help="儲存相關指令")
 app.add_typer(storage_app, name="storage")
 
-backup_app = typer.Typer(help="Backup and restore commands")
+backup_app = typer.Typer(help="備份與還原指令")
 app.add_typer(backup_app, name="backup")
 
-orchestrator_app = typer.Typer(help="Orchestrator commands")
+orchestrator_app = typer.Typer(help="Orchestrator 指令")
 app.add_typer(orchestrator_app, name="orchestrator")
 
 
@@ -75,7 +75,7 @@ def trace(table: str, db: str = ":memory:") -> None:
     catalog = Catalog(db_path=db)
     entry: CatalogEntry | None = catalog.get(table)
     if not entry:
-        typer.echo(f"Table {table} not found")
+        typer.echo(f"找不到表格 {table}")
         raise typer.Exit(code=1)
 
     msg = (
@@ -101,22 +101,22 @@ def walk_forward(
 
 @storage_app.command()
 def migrate(
-    table: str = typer.Option(..., "--table", help="Table to move"),
-    to: str = typer.Option(..., "--to", help="Target tier"),
-    db: str = typer.Option(":memory:", "--db", help="Catalog location"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show expected action only"),
+    table: str = typer.Option(..., "--table", help="要移動的表格名稱"),
+    to: str = typer.Option(..., "--to", help="目標層級"),
+    db: str = typer.Option(":memory:", "--db", help="Catalog 位置"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="僅顯示預期動作"),
 ) -> None:
     """將表格搬移至指定層級。"""
     manager = HybridStorageManager(catalog=Catalog(db_path=db))
     entry = manager.catalog.get(table)
     if entry is None:
-        typer.echo(f"Table {table} not found")
+        typer.echo(f"找不到表格 {table}")
         raise typer.Exit(code=1)
     if dry_run:
-        typer.echo(f"Will move {table} from {entry.tier} to {to}")
+        typer.echo(f"將把 {table} 從 {entry.tier} 移至 {to}")
     else:
         manager.migrate(table, entry.tier, to)
-        typer.echo(f"Moved {table} from {entry.tier} to {to}")
+        typer.echo(f"已將 {table} 從 {entry.tier} 移至 {to}")
 
 
 @backup_app.command()
@@ -125,7 +125,7 @@ def verify(latest: bool = False) -> None:
     if latest:
         verify_latest()
     else:
-        typer.echo("Please use the --latest parameter")
+        typer.echo("請使用 --latest 參數")
 
 
 def _get_strategy_cls(strategy_name: str) -> Type[StrategyBase]:
@@ -180,16 +180,16 @@ def _run_orchestrator(config_path: Path, use_ray: bool):
     output_file = f"{config['run_id']}_results.json"
     orchestrator.to_json(output_file)
     orchestrator.generate_reports()
-    typer.echo(f"Backtest complete. Results saved to {output_file}")
+    typer.echo(f"回測完成，結果已寫入 {output_file}")
 
 
 @orchestrator_app.command("run-wfa")
 def run_wfa(
     config_path: Path = typer.Option(
-        ..., "--config", help="Path to the walk-forward config file"
+        ..., "--config", help="Walk-Forward 設定檔路徑"
     ),
     use_ray: bool = typer.Option(
-        True, "--ray/--no-ray", help="Use Ray for parallel execution"
+        True, "--ray/--no-ray", help="是否使用 Ray 平行執行"
     ),
 ):
     """執行 Walk-Forward 分析。"""
@@ -199,10 +199,10 @@ def run_wfa(
 @orchestrator_app.command("run-cpcv")
 def run_cpcv(
     config_path: Path = typer.Option(
-        ..., "--config", help="Path to the CPCV config file"
+        ..., "--config", help="CPCV 設定檔路徑"
     ),
     use_ray: bool = typer.Option(
-        True, "--ray/--no-ray", help="Use Ray for parallel execution"
+        True, "--ray/--no-ray", help="是否使用 Ray 平行執行"
     ),
 ):
     """執行 Combinatorial Purged Cross-Validation。"""
@@ -215,13 +215,13 @@ app.add_typer(report_app, name="report")
 
 @report_app.command("generate")
 def generate_report(
-    run_id: str = typer.Option(..., "--run-id", help="Run ID of the backtest"),
-    fmt: str = typer.Option("pdf", "--fmt", help="Output format (pdf, json)"),
+    run_id: str = typer.Option(..., "--run-id", help="回測執行的 Run ID"),
+    fmt: str = typer.Option("pdf", "--fmt", help="輸出格式 (pdf, json)"),
 ):
     """為指定 run ID 產生報告。"""
     results_path = Path(f"{run_id}_results.json")
     if not results_path.exists():
-        typer.echo(f"Results file for run ID '{run_id}' not found.")
+        typer.echo(f"找不到 Run ID '{run_id}' 的結果檔案")
         raise typer.Exit(code=1)
 
     with open(results_path) as f:
@@ -232,15 +232,15 @@ def generate_report(
     if fmt == "pdf":
         output_file = Path(f"report_{run_id}.pdf")
         report_gen.generate_pdf(output_file)
-        typer.echo(f"PDF report generated at {output_file}")
+        typer.echo(f"已產生 PDF 報告於 {output_file}")
     elif fmt == "json":
         output_file = Path(f"report_{run_id}.json")
         json_output = report_gen.generate_json()
         with open(output_file, "w") as f:
             f.write(json_output)
-        typer.echo(f"JSON report generated at {output_file}")
+        typer.echo(f"已產生 JSON 報告於 {output_file}")
     else:
-        typer.echo(f"Unknown format: {fmt}")
+        typer.echo(f"未知的格式：{fmt}")
         raise typer.Exit(code=1)
 
 

--- a/tests/data_processing/test_cross_validation.py
+++ b/tests/data_processing/test_cross_validation.py
@@ -59,8 +59,8 @@ class TestCrossValidation(unittest.TestCase):
             self.assertEqual(len(test), test_size)
 
     def test_run_cpcv(self):
-        # This is a basic test to ensure the function runs without errors.
-        # A more thorough test would require a more complex mock strategy.
+        # 基本測試，確認函式能順利執行
+        # 更完整的測試需搭配複雜的模擬策略
         result = run_cpcv(
             self.data, mock_strategy, n_splits=5, n_test_splits=2, embargo_pct=0.05
         )


### PR DESCRIPTION
## Summary
- translate various comments and docstrings into Traditional Chinese
- localize CLI help messages and outputs
- update example scripts and documentation

## Testing
- `flake8` *(failed: command not found)*
- `pytest` *(failed to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b48a73180832faa3ee1b8e871765d